### PR TITLE
Storing helmfile separately from project repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dev
+.idea

--- a/src/argo-cd-helmfile.sh
+++ b/src/argo-cd-helmfile.sh
@@ -169,7 +169,7 @@ case $phase in
 
     # download helmfile and values from remote repo
     if [ ! -e "helmfile.yaml" ]; then
-      curl --header "PRIVATE-TOKEN: $GITLAB_TOKEN_HELM_CHARTS" "https://gitlab.task4work.info/api/v4/projects/298/repository/archive?sha=$HELM_CHARTS_BRANCH&path=projects/$BASE_APP_NAME" --output "app-deploy.tar"
+      curl --header "PRIVATE-TOKEN: $GITLAB_TOKEN_HELM_CHARTS" "$PROJECT_DEPLOY_DIR_URL" --output "app-deploy.tar"
       mkdir "app-deploy-tmp"
       tar -xf "./app-deploy.tar" -C "./app-deploy-tmp"
       cp -r "$(find ./app-deploy-tmp -name "helmfile.yaml" | sed 's/helmfile.yaml/./g')" .

--- a/src/argo-cd-helmfile.sh
+++ b/src/argo-cd-helmfile.sh
@@ -170,6 +170,7 @@ case $phase in
     # download helmfile and values from remote repo
     if [ ! -e "helmfile.yaml" ]; then
       curl --header "PRIVATE-TOKEN: $GITLAB_TOKEN_HELM_CHARTS" "$PROJECT_DEPLOY_DIR_URL" --output "app-deploy.tar"
+      echo "DEBUG!! $PROJECT_DEPLOY_DIR_URL"
       mkdir "app-deploy-tmp"
       tar -xf "./app-deploy.tar" -C "./app-deploy-tmp"
       cp -r "$(find ./app-deploy-tmp -name "helmfile.yaml" | sed 's/helmfile.yaml/./g')" .

--- a/src/argo-cd-helmfile.sh
+++ b/src/argo-cd-helmfile.sh
@@ -172,7 +172,7 @@ case $phase in
     # download helmfile and values from remote repo
     if [ ! -e "helmfile.yaml" ]; then
       echoerr "DEBUG!! INSIDE"
-      curl --header "PRIVATE-TOKEN: $GITLAB_TOKEN_HELM_CHARTS" "https://gitlab.task4work.info/api/v4/projects/298/repository/archive?sha=$HELM_CHARTS_BRANCH&path=projects/$BASE_APP_NAME " --output "app-deploy.tar"
+      curl --header "PRIVATE-TOKEN: $GITLAB_TOKEN_HELM_CHARTS" "https://gitlab.task4work.info/api/v4/projects/298/repository/archive?sha=$HELM_CHARTS_BRANCH&path=projects/$BASE_APP_NAME" --output "app-deploy.tar"
       mkdir "app-deploy-tmp"
       tar -xf "./app-deploy.tar" -C "./app-deploy-tmp"
       cp -r "$(find ./app-deploy-tmp -name "helmfile.yaml" | sed 's/helmfile.yaml/./g')" .

--- a/src/argo-cd-helmfile.sh
+++ b/src/argo-cd-helmfile.sh
@@ -167,6 +167,13 @@ case $phase in
   "init")
     echoerr "starting init"
 
+    projectDeployDirName=$ARGOCD_APP_NAME-deploy
+    curl --header "PRIVATE-TOKEN: $GITLAB_TOKEN_HELM_CHARTS" "$PROJECT_DEPLOY_DIR_URL" --output "$projectDeployDirName.tar"
+    mkdir "$projectDeployDirName-tmp"
+    tar -xf "./$projectDeployDirName.tar" -C "./$projectDeployDirName-tmp"
+    cp -r "$projectDeployDirName-tmp/$(ls ./$projectDeployDirName | head -1)/projects/$ARGOCD_APP_NAME" "./$projectDeployDirName"
+    rm -rf "$projectDeployDirName-tmp"
+
     # ensure dir(s)
     # rm -rf "${HELM_HOME}"
     if [[ ! -d "${HELM_HOME}" ]]; then

--- a/src/argo-cd-helmfile.sh
+++ b/src/argo-cd-helmfile.sh
@@ -167,11 +167,8 @@ case $phase in
   "init")
     echoerr "starting init"
 
-    echoerr "DEBUG!! $PROJECT_DEPLOY_DIR_URL"
-
     # download helmfile and values from remote repo
     if [ ! -e "helmfile.yaml" ]; then
-      echoerr "DEBUG!! INSIDE"
       curl --header "PRIVATE-TOKEN: $GITLAB_TOKEN_HELM_CHARTS" "https://gitlab.task4work.info/api/v4/projects/298/repository/archive?sha=$HELM_CHARTS_BRANCH&path=projects/$BASE_APP_NAME" --output "app-deploy.tar"
       mkdir "app-deploy-tmp"
       tar -xf "./app-deploy.tar" -C "./app-deploy-tmp"

--- a/src/argo-cd-helmfile.sh
+++ b/src/argo-cd-helmfile.sh
@@ -11,6 +11,9 @@
 # HELMFILE_INIT_SCRIPT_FILE - path to script to execute during the init phase
 # HELMFILE_USE_CONTEXT_NAMESPACE - do not set helmfile namespace to ARGOCD_APP_NAMESPACE (for multi-namespace apps)
 # HELM_DATA_HOME - perform variable expansion
+# HELMFILE_LOCATION - path to helmfile.yaml in project directory, default - ./helmfile.yaml
+# GITLAB_TOKEN_HELM_CHARTS - token for read repo with helmfile and values
+# PROJECT_DEPLOY_DIR_URL - url to project deploy directory, which contains helmfile and values
 
 # NOTE: only 1 -f value/file/dir is used by helmfile, while you can specific -f multiple times
 # only the last one matters and all previous -f arguments are irrelevant
@@ -168,7 +171,7 @@ case $phase in
     echoerr "starting init"
 
     # download helmfile and values from remote repo
-    if [ ! -e "helmfile.yaml" ]; then
+    if [ ! -e "$HELMFILE_LOCATION" ]; then
       curl --header "PRIVATE-TOKEN: $GITLAB_TOKEN_HELM_CHARTS" "$PROJECT_DEPLOY_DIR_URL" --output "app-deploy.tar"
       mkdir "app-deploy-tmp"
       tar -xf "./app-deploy.tar" -C "./app-deploy-tmp"

--- a/src/argo-cd-helmfile.sh
+++ b/src/argo-cd-helmfile.sh
@@ -170,8 +170,10 @@ case $phase in
   "init")
     echoerr "starting init"
 
+    helmfileLocation=${HELMFILE_LOCATION:-"helmfile.yaml"}
+
     # download helmfile and values from remote repo
-    if [ ! -e "$HELMFILE_LOCATION" ]; then
+    if [ ! -e "$helmfileLocation" ]; then
       curl --header "PRIVATE-TOKEN: $GITLAB_TOKEN_HELM_CHARTS" "$PROJECT_DEPLOY_DIR_URL" --output "app-deploy.tar"
       mkdir "app-deploy-tmp"
       tar -xf "./app-deploy.tar" -C "./app-deploy-tmp"

--- a/src/argo-cd-helmfile.sh
+++ b/src/argo-cd-helmfile.sh
@@ -167,12 +167,14 @@ case $phase in
   "init")
     echoerr "starting init"
 
-    projectDeployDirName=$ARGOCD_APP_NAME-deploy
-    curl --header "PRIVATE-TOKEN: $GITLAB_TOKEN_HELM_CHARTS" "$PROJECT_DEPLOY_DIR_URL" --output "$projectDeployDirName.tar"
-    mkdir "$projectDeployDirName-tmp"
-    tar -xf "./$projectDeployDirName.tar" -C "./$projectDeployDirName-tmp"
-    cp -r "$projectDeployDirName-tmp/$(ls ./$projectDeployDirName | head -1)/projects/$ARGOCD_APP_NAME" "./$projectDeployDirName"
-    rm -rf "$projectDeployDirName-tmp"
+    # download helmfile and values from remote repo
+    if [ ! -e "helmfile.yaml" ]; then
+      curl --header "PRIVATE-TOKEN: $GITLAB_TOKEN_HELM_CHARTS" "$PROJECT_DEPLOY_DIR_URL" --output "app-deploy.tar"
+      mkdir "app-deploy-tmp"
+      tar -xf "./app-deploy.tar" -C "./app-deploy-tmp"
+      cp -r "$(find ./app-deploy-tmp -name "helmfile.yaml" | sed 's/helmfile.yaml/./g')" .
+      rm -rf "app-deploy-tmp"
+    fi
 
     # ensure dir(s)
     # rm -rf "${HELM_HOME}"

--- a/src/argo-cd-helmfile.sh
+++ b/src/argo-cd-helmfile.sh
@@ -173,7 +173,7 @@ case $phase in
     helmfileLocation=${HELMFILE_LOCATION:-"helmfile.yaml"}
 
     # download helmfile and values from remote repo
-    if [ ! -e "$helmfileLocation" ]; then
+    if [[ ! -e "$helmfileLocation" && -n "$PROJECT_DEPLOY_DIR_URL" ]]; then
       curl --header "PRIVATE-TOKEN: $GITLAB_TOKEN_HELM_CHARTS" "$PROJECT_DEPLOY_DIR_URL" --output "app-deploy.tar"
       mkdir "app-deploy-tmp"
       tar -xf "./app-deploy.tar" -C "./app-deploy-tmp"

--- a/src/argo-cd-helmfile.sh
+++ b/src/argo-cd-helmfile.sh
@@ -167,10 +167,12 @@ case $phase in
   "init")
     echoerr "starting init"
 
+    echo "DEBUG!! $PROJECT_DEPLOY_DIR_URL"
+
     # download helmfile and values from remote repo
     if [ ! -e "helmfile.yaml" ]; then
+      echo "DEBUG!! INSIDE"
       curl --header "PRIVATE-TOKEN: $GITLAB_TOKEN_HELM_CHARTS" "$PROJECT_DEPLOY_DIR_URL" --output "app-deploy.tar"
-      echo "DEBUG!! $PROJECT_DEPLOY_DIR_URL"
       mkdir "app-deploy-tmp"
       tar -xf "./app-deploy.tar" -C "./app-deploy-tmp"
       cp -r "$(find ./app-deploy-tmp -name "helmfile.yaml" | sed 's/helmfile.yaml/./g')" .

--- a/src/argo-cd-helmfile.sh
+++ b/src/argo-cd-helmfile.sh
@@ -167,12 +167,12 @@ case $phase in
   "init")
     echoerr "starting init"
 
-    echo "DEBUG!! $PROJECT_DEPLOY_DIR_URL"
+    echoerr "DEBUG!! $PROJECT_DEPLOY_DIR_URL"
 
     # download helmfile and values from remote repo
     if [ ! -e "helmfile.yaml" ]; then
-      echo "DEBUG!! INSIDE"
-      curl --header "PRIVATE-TOKEN: $GITLAB_TOKEN_HELM_CHARTS" "$PROJECT_DEPLOY_DIR_URL" --output "app-deploy.tar"
+      echoerr "DEBUG!! INSIDE"
+      curl --header "PRIVATE-TOKEN: $GITLAB_TOKEN_HELM_CHARTS" "https://gitlab.task4work.info/api/v4/projects/298/repository/archive?sha=$HELM_CHARTS_BRANCH&path=projects/$BASE_APP_NAME " --output "app-deploy.tar"
       mkdir "app-deploy-tmp"
       tar -xf "./app-deploy.tar" -C "./app-deploy-tmp"
       cp -r "$(find ./app-deploy-tmp -name "helmfile.yaml" | sed 's/helmfile.yaml/./g')" .


### PR DESCRIPTION
Sometimes its comfortable to store helmfile.yaml and values separately from project repo. 
My MR allows to pass url, where you store helmfile. At first script downloads helmfile.yaml with other required files, then uses this helmfile for generate manifests.

Env variables was added:
- HELMFILE_LOCATION - path, which will be checked, if helmfile.yaml exists, before starts script. Script will be executed if this helmfile doesnt exist in project path AND you passes PROJECT_DEPLOY_DIR_URL. By default - ./helmfile.yaml
- GITLAB_TOKEN_HELM_CHARTS - token for gitlab auth.
- PROJECT_DEPLOY_DIR_URL - url, where helmfile is stored. For example: https://gitlab.com/api/v4/projects/100/repository/archive?sha=branch-name&path=projects/example-project
